### PR TITLE
Return the original inputted value for the custom option of type date…

### DIFF
--- a/app/code/Magento/QuoteGraphQl/Model/Resolver/CustomizableOptions.php
+++ b/app/code/Magento/QuoteGraphQl/Model/Resolver/CustomizableOptions.php
@@ -58,8 +58,29 @@ class CustomizableOptions implements ResolverInterface
                 $cartItem,
                 (int)$customizableOptionId
             );
+
+            if ('date_time' === $customizableOption['type']) {
+                $this->setOriginalDateTime($cartItem, $customizableOption, $customizableOptionId);
+            }
+
             $customizableOptionsData[] = $customizableOption;
         }
         return $customizableOptionsData;
+    }
+
+    public function setOriginalDateTime(QuoteItem $cartItem, &$customizableOption, $customizableOptionId)
+    {
+        $originalOption = $cartItem->getOptionsByCode();
+
+        if (is_array($originalOption)
+            && is_string($customizableOptionId)
+            && array_key_exists('option_' . $customizableOptionId, $originalOption)
+        ) {
+            $originalValue = $originalOption['option_' . $customizableOptionId]->getOrigData()['value'];
+
+            if ('' !== $originalValue) {
+                $customizableOption['values'][0]['value'] = $originalValue;
+            }
+        }
     }
 }


### PR DESCRIPTION
…_time

As the date and time type customizable options still return an error in graphQL I have limited the scope of this solution to the sole purpose of returning the original date_time value.

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
As the date and time type customizable options still return an error in graphQL I have limited the scope of this solution to the sole purpose of returning the original date_time value.
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. https://github.com/magento/graphql-ce/issues/1000: Date, time and date&time customizable options should havу the same format in output and input

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Add a product to cart with GraphQL that has a customizable option of type date_time.
2. See if the returned object contains the exact same stamp.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
I have not had the feeling this was the correct location of solving the problem as the Resolver might not to be concerned with the format of the output. I would like some feedback on this solution.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
